### PR TITLE
4 create problem image api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
+/postgres_data_problem

--- a/build.gradle
+++ b/build.gradle
@@ -43,9 +43,11 @@ dependencies {
 	// Test
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-//	// QueryDSL
-//	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-//	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	// https://mvnrepository.com/artifact/com.querydsl/querydsl-apt
+	implementation group: 'com.querydsl', name: 'querydsl-apt', version: '5.0.0'
+
 }
 
 ext {
@@ -61,4 +63,13 @@ dependencyManagement {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+	main.java.srcDirs += [ querydslDir ]
+}
+
+clean.doLast {
+	file(querydslDir).deleteDir()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	// Test
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+//	// QueryDSL
+//	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+//	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -43,10 +43,6 @@ dependencies {
 	// Test
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	// QueryDSL
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	// https://mvnrepository.com/artifact/com.querydsl/querydsl-apt
-	implementation group: 'com.querydsl', name: 'querydsl-apt', version: '5.0.0'
 
 }
 
@@ -63,13 +59,4 @@ dependencyManagement {
 
 tasks.named('test') {
 	useJUnitPlatform()
-}
-def querydslDir = "$buildDir/generated/querydsl"
-
-sourceSets {
-	main.java.srcDirs += [ querydslDir ]
-}
-
-clean.doLast {
-	file(querydslDir).deleteDir()
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,27 +9,27 @@ services:
       POSTGRES_USER: springproblem
       POSTGRES_PASSWORD: abcd1234
     volumes:
-      - postgres_data_problem:/var/lib/postgresql/data
+      - ./postgres_data_problem:/var/lib/postgresql/data
     ports:
       - "5433:5432"
 
-  springboot_problem:
-    build: .
-    container_name: springboot_problem
-    environment:
-      SPRING_DATASOURCE_URL: jdbc:postgresql://postgresql_problem:5432/springdb_problem
-      SPRING_DATASOURCE_USERNAME: springproblem
-      SPRING_DATASOURCE_PASSWORD: password
-      SERVER_SSL_KEY_STORE: /app/key1.p12
-      SERVER_SSL_KEY_STORE_PASSWORD: abcd1234
-      SERVER_SSL_KEY_STORE_TYPE: PKCS12
-      SERVER_SSL_KEY_ALIAS: tomcat
-    volumes:
-        - ./key1.p12:/app/key1.p12
-    ports:
-      - "7070:8443"
-    depends_on:
-      - postgresql_problem
+#  springboot_problem:
+#    build: .
+#    container_name: springboot_problem
+#    environment:
+#      SPRING_DATASOURCE_URL: jdbc:postgresql://postgresql_problem:5432/springdb_problem
+#      SPRING_DATASOURCE_USERNAME: springproblem
+#      SPRING_DATASOURCE_PASSWORD: password
+#      SERVER_SSL_KEY_STORE: /app/key1.p12
+#      SERVER_SSL_KEY_STORE_PASSWORD: abcd1234
+#      SERVER_SSL_KEY_STORE_TYPE: PKCS12
+#      SERVER_SSL_KEY_ALIAS: tomcat
+#    volumes:
+#        - ./key1.p12:/app/key1.p12
+#    ports:
+#      - "7070:8443"
+#    depends_on:
+#      - postgresql_problem
 
 volumes:
   postgres_data_problem:

--- a/src/main/java/Problem/Math/AI/common/AnalysisType.java
+++ b/src/main/java/Problem/Math/AI/common/AnalysisType.java
@@ -1,8 +1,8 @@
 package Problem.Math.AI.common;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 
-@Getter
 public enum AnalysisType {
     ATTEMPT("attempt"),
     QUESTION("question");
@@ -11,4 +11,8 @@ public enum AnalysisType {
         this.type = type;
     }
 
+    @JsonValue
+    public String getType(){
+        return type;
+    }
 }

--- a/src/main/java/Problem/Math/AI/common/AnalysisType.java
+++ b/src/main/java/Problem/Math/AI/common/AnalysisType.java
@@ -6,9 +6,7 @@ import lombok.Getter;
 public enum AnalysisType {
     ATTEMPT("attempt"),
     QUESTION("question");
-
     private final String type;
-
     AnalysisType (String type){
         this.type = type;
     }

--- a/src/main/java/Problem/Math/AI/common/AnalysisType.java
+++ b/src/main/java/Problem/Math/AI/common/AnalysisType.java
@@ -1,0 +1,16 @@
+package Problem.Math.AI.common;
+
+import lombok.Getter;
+
+@Getter
+public enum AnalysisType {
+    ATTEMPT("attempt"),
+    QUESTION("question");
+
+    private final String type;
+
+    AnalysisType (String type){
+        this.type = type;
+    }
+
+}

--- a/src/main/java/Problem/Math/AI/common/dto/ContentRequest.java
+++ b/src/main/java/Problem/Math/AI/common/dto/ContentRequest.java
@@ -1,0 +1,13 @@
+package Problem.Math.AI.common.dto;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ContentRequest {
+    private String imgUrl;
+}

--- a/src/main/java/Problem/Math/AI/common/dto/ContentRequest.java
+++ b/src/main/java/Problem/Math/AI/common/dto/ContentRequest.java
@@ -2,11 +2,13 @@ package Problem.Math.AI.common.dto;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ContentRequest {
     private String imgUrl;

--- a/src/main/java/Problem/Math/AI/common/entity/BaseEntity.java
+++ b/src/main/java/Problem/Math/AI/common/entity/BaseEntity.java
@@ -1,19 +1,20 @@
-package Problem.Math.AI.domain;
+package Problem.Math.AI.common.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @MappedSuperclass
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ContentEntity {
-
+public class BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    @Column(name = "img_url")
-    private String imgUrl;
+    @Column(name = "create_date")
+    private LocalDateTime createDate;
 }

--- a/src/main/java/Problem/Math/AI/common/entity/BaseEntity.java
+++ b/src/main/java/Problem/Math/AI/common/entity/BaseEntity.java
@@ -3,6 +3,7 @@ package Problem.Math.AI.common.entity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BaseEntity {
     @Id
+    @Getter
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 

--- a/src/main/java/Problem/Math/AI/common/entity/BaseEntity.java
+++ b/src/main/java/Problem/Math/AI/common/entity/BaseEntity.java
@@ -4,9 +4,11 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDateTime;
 
+@SuperBuilder
 @MappedSuperclass
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/Problem/Math/AI/common/entity/ContentEntity.java
+++ b/src/main/java/Problem/Math/AI/common/entity/ContentEntity.java
@@ -1,20 +1,19 @@
-package Problem.Math.AI.domain;
+package Problem.Math.AI.common.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @MappedSuperclass
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class BaseEntity {
+public class ContentEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    @Column(name = "create_date")
-    private LocalDateTime createDate;
+    @Column(name = "img_url")
+    private String imgUrl;
 }

--- a/src/main/java/Problem/Math/AI/common/entity/ContentEntity.java
+++ b/src/main/java/Problem/Math/AI/common/entity/ContentEntity.java
@@ -4,7 +4,9 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
+@SuperBuilder
 @MappedSuperclass
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/Problem/Math/AI/domain/attempt/AttemptContentEntity.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/AttemptContentEntity.java
@@ -6,9 +6,10 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
-@Builder
+@SuperBuilder
 @Table(name = "attempt_content")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/Problem/Math/AI/domain/attempt/AttemptContentEntity.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/AttemptContentEntity.java
@@ -1,6 +1,6 @@
 package Problem.Math.AI.domain.attempt;
 
-import Problem.Math.AI.domain.ContentEntity;
+import Problem.Math.AI.common.entity.ContentEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/Problem/Math/AI/domain/attempt/AttemptMarkGPTMapper.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/AttemptMarkGPTMapper.java
@@ -5,7 +5,8 @@ import Problem.Math.AI.domain.attempt.dto.AttemptMarkRequest;
 
 public class AttemptMarkGPTMapper {
 
-    public static AttemptAnalysisRequest mapTo(AttemptMarkRequest request, Long attempId){
+    public static AttemptAnalysisRequest mapTo(AttemptMarkRequest request, Long attemptId){
+
         return null;
     }
 }

--- a/src/main/java/Problem/Math/AI/domain/attempt/AttemptMarkGPTMapper.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/AttemptMarkGPTMapper.java
@@ -1,0 +1,11 @@
+package Problem.Math.AI.domain.attempt;
+
+import Problem.Math.AI.domain.attempt.dto.AttemptAnalysisRequest;
+import Problem.Math.AI.domain.attempt.dto.AttemptMarkRequest;
+
+public class AttemptMarkGPTMapper {
+
+    public static AttemptAnalysisRequest mapTo(AttemptMarkRequest request, Long attempId){
+        return null;
+    }
+}

--- a/src/main/java/Problem/Math/AI/domain/attempt/ProblemAttempt.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/ProblemAttempt.java
@@ -4,12 +4,13 @@ import Problem.Math.AI.common.entity.BaseEntity;
 import Problem.Math.AI.domain.problem.entity.Problem;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 /**
  * 학생이 문제를 푼 값.
  */
 @Entity
-@Builder
+@SuperBuilder
 @Table(name = "problem_attempt")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/Problem/Math/AI/domain/attempt/ProblemAttempt.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/ProblemAttempt.java
@@ -1,6 +1,6 @@
 package Problem.Math.AI.domain.attempt;
 
-import Problem.Math.AI.domain.BaseEntity;
+import Problem.Math.AI.common.entity.BaseEntity;
 import Problem.Math.AI.domain.problem.entity.Problem;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/Problem/Math/AI/domain/attempt/controller/AttemptController.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/controller/AttemptController.java
@@ -1,0 +1,24 @@
+package Problem.Math.AI.domain.attempt.controller;
+
+import Problem.Math.AI.domain.attempt.dto.AttemptMarkRequest;
+import Problem.Math.AI.domain.attempt.service.AttemptService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/attempt")
+public class AttemptController {
+
+    private final AttemptService attemptService;
+
+    @PostMapping
+    public void sendAttemptToMarking(@RequestBody AttemptMarkRequest attempt){
+        attemptService.markAttemptSolution(attempt);
+    }
+}

--- a/src/main/java/Problem/Math/AI/domain/attempt/controller/AttemptController.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/controller/AttemptController.java
@@ -1,9 +1,11 @@
 package Problem.Math.AI.domain.attempt.controller;
 
 import Problem.Math.AI.domain.attempt.dto.AttemptMarkRequest;
+import Problem.Math.AI.domain.attempt.dto.SimpleMarkResponse;
 import Problem.Math.AI.domain.attempt.service.AttemptService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,7 +20,8 @@ public class AttemptController {
     private final AttemptService attemptService;
 
     @PostMapping
-    public void sendAttemptToMarking(@RequestBody AttemptMarkRequest attempt){
-        attemptService.markAttemptSolution(attempt);
+    public ResponseEntity<SimpleMarkResponse> sendAttemptToMarking(@RequestBody AttemptMarkRequest attempt){
+        SimpleMarkResponse response = attemptService.markAttemptSolution(attempt);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/Problem/Math/AI/domain/attempt/controller/AttemptController.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/controller/AttemptController.java
@@ -22,6 +22,7 @@ public class AttemptController {
     @PostMapping
     public ResponseEntity<SimpleMarkResponse> sendAttemptToMarking(@RequestBody AttemptMarkRequest attempt){
         SimpleMarkResponse response = attemptService.markAttemptSolution(attempt);
+        log.info("id : {}, status : {}",response.getProblemId(), response.getStatus().getStatus());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/Problem/Math/AI/domain/attempt/dto/AttemptAnalysisRequest.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/dto/AttemptAnalysisRequest.java
@@ -1,0 +1,17 @@
+package Problem.Math.AI.domain.attempt.dto;
+
+import Problem.Math.AI.common.AnalysisType;
+import Problem.Math.AI.domain.gpt.dto.VisionReqDto;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Builder
+@AllArgsConstructor
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class AttemptAnalysisRequest{
+    private Long attemptId;
+    private AnalysisType type;
+    private VisionReqDto visionReqDto;
+}

--- a/src/main/java/Problem/Math/AI/domain/attempt/dto/AttemptMarkRequest.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/dto/AttemptMarkRequest.java
@@ -14,7 +14,6 @@ import java.util.List;
 @JsonNaming(value = PropertyNamingStrategy.class)
 public class  AttemptMarkRequest{
     private Long problemId;
-    private AttemptType attemptType;
     private List<ContentRequest> imgUrlsContent;
     private String textContent;
     private Integer answer;

--- a/src/main/java/Problem/Math/AI/domain/attempt/dto/AttemptMarkRequest.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/dto/AttemptMarkRequest.java
@@ -2,7 +2,7 @@ package Problem.Math.AI.domain.attempt.dto;
 
 import Problem.Math.AI.common.dto.ContentRequest;
 import Problem.Math.AI.domain.attempt.entity.AttemptType;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,9 +11,10 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
-@JsonNaming(value = PropertyNamingStrategy.class)
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class  AttemptMarkRequest{
     private Long problemId;
+    private AttemptType type;
     private List<ContentRequest> imgUrlsContent;
     private String textContent;
     private Integer answer;

--- a/src/main/java/Problem/Math/AI/domain/attempt/dto/AttemptMarkRequest.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/dto/AttemptMarkRequest.java
@@ -1,0 +1,20 @@
+package Problem.Math.AI.domain.attempt.dto;
+
+import Problem.Math.AI.common.dto.ContentRequest;
+import Problem.Math.AI.domain.attempt.entity.AttemptType;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonNaming(value = PropertyNamingStrategy.class)
+public class  AttemptMarkRequest{
+    private Long problemId;
+    private AttemptType attemptType;
+    private List<ContentRequest> imgUrls;
+    private Integer answer;
+}

--- a/src/main/java/Problem/Math/AI/domain/attempt/dto/AttemptMarkRequest.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/dto/AttemptMarkRequest.java
@@ -15,6 +15,8 @@ import java.util.List;
 public class  AttemptMarkRequest{
     private Long problemId;
     private AttemptType attemptType;
-    private List<ContentRequest> imgUrls;
+    private List<ContentRequest> imgUrlsContent;
+    private String textContent;
     private Integer answer;
+    private Long userId;
 }

--- a/src/main/java/Problem/Math/AI/domain/attempt/dto/SimpleMarkResponse.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/dto/SimpleMarkResponse.java
@@ -5,11 +5,16 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
 @Builder
+@NoArgsConstructor
 @AllArgsConstructor
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class SimpleMarkResponse {
+    private Long attemptId;
     private Long problemId;
     private Status status;
 }

--- a/src/main/java/Problem/Math/AI/domain/attempt/dto/SimpleMarkResponse.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/dto/SimpleMarkResponse.java
@@ -1,0 +1,15 @@
+package Problem.Math.AI.domain.attempt.dto;
+
+import Problem.Math.AI.domain.attempt.entity.Status;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+@Builder
+@AllArgsConstructor
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class SimpleMarkResponse {
+    private Long problemId;
+    private Status status;
+}

--- a/src/main/java/Problem/Math/AI/domain/attempt/entity/AttemptContentEntity.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/entity/AttemptContentEntity.java
@@ -1,10 +1,9 @@
-package Problem.Math.AI.domain.attempt;
+package Problem.Math.AI.domain.attempt.entity;
 
 import Problem.Math.AI.common.entity.ContentEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 

--- a/src/main/java/Problem/Math/AI/domain/attempt/entity/AttemptContentEntity.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/entity/AttemptContentEntity.java
@@ -15,6 +15,6 @@ import lombok.experimental.SuperBuilder;
 public class AttemptContentEntity extends ContentEntity {
 
     @ManyToOne
-    @JoinColumn(name = "problem_attempt")
+    @JoinColumn(name = "problem_attempt_id")
     private ProblemAttempt problemAttempt;
 }

--- a/src/main/java/Problem/Math/AI/domain/attempt/entity/AttemptType.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/entity/AttemptType.java
@@ -1,8 +1,8 @@
 package Problem.Math.AI.domain.attempt.entity;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.Getter;
 
-@Getter
 public enum AttemptType {
     TEXT("text"),
     IMAGE_URL("url");
@@ -10,5 +10,10 @@ public enum AttemptType {
     private final String type;
     AttemptType(String type){
         this.type = type;
+    }
+
+    @JsonValue
+    public String getType(){
+        return type;
     }
 }

--- a/src/main/java/Problem/Math/AI/domain/attempt/entity/AttemptType.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/entity/AttemptType.java
@@ -1,0 +1,14 @@
+package Problem.Math.AI.domain.attempt.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum AttemptType {
+    TEXT("text"),
+    IMAGE_URL("url");
+
+    private final String type;
+    AttemptType(String type){
+        this.type = type;
+    }
+}

--- a/src/main/java/Problem/Math/AI/domain/attempt/entity/ProblemAttempt.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/entity/ProblemAttempt.java
@@ -1,10 +1,18 @@
 package Problem.Math.AI.domain.attempt.entity;
 
+import Problem.Math.AI.common.dto.ContentRequest;
 import Problem.Math.AI.common.entity.BaseEntity;
+import Problem.Math.AI.domain.attempt.dto.AttemptMarkRequest;
 import Problem.Math.AI.domain.problem.entity.Problem;
+import Problem.Math.AI.domain.problem.entity.SolutionContentEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * 학생이 문제를 푼 값.
@@ -23,9 +31,7 @@ public class ProblemAttempt extends BaseEntity {
     @Column
     private String content;
 
-    @Column(name = "is_success")
-    private Boolean isSuccess;
-
+    @Getter
     @Enumerated(EnumType.STRING)
     @Column
     private Status status;
@@ -35,4 +41,28 @@ public class ProblemAttempt extends BaseEntity {
 
     @Column
     private Integer answer;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    @JoinColumn(name = "problem_attempt_id")
+    private Set<AttemptContentEntity> attemptContents;
+
+
+
+    public static ProblemAttempt toEntity(AttemptMarkRequest request, Problem problem, Status status){
+        return ProblemAttempt.builder()
+                .createDate(LocalDateTime.now())
+                .problem(problem)
+                .content(request.getTextContent())
+                .status(status)
+                .userId(request.getUserId())
+                .answer(request.getAnswer())
+                .attemptContents(toEntity(request.getImgUrlsContent()))
+                .build();
+    }
+
+    private static Set<AttemptContentEntity> toEntity(List<ContentRequest> requests){
+        return requests.parallelStream().map( req -> AttemptContentEntity.builder()
+                        .imgUrl(req.getImgUrl()).build())
+                .collect(Collectors.toSet());
+    }
 }

--- a/src/main/java/Problem/Math/AI/domain/attempt/entity/ProblemAttempt.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/entity/ProblemAttempt.java
@@ -1,4 +1,4 @@
-package Problem.Math.AI.domain.attempt;
+package Problem.Math.AI.domain.attempt.entity;
 
 import Problem.Math.AI.common.entity.BaseEntity;
 import Problem.Math.AI.domain.problem.entity.Problem;

--- a/src/main/java/Problem/Math/AI/domain/attempt/entity/Status.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/entity/Status.java
@@ -1,8 +1,7 @@
 package Problem.Math.AI.domain.attempt.entity;
 
-import lombok.Getter;
+import com.fasterxml.jackson.annotation.JsonValue;
 
-@Getter
 public enum Status {
     PENDING("pending"),
     SUCCESS("success"),
@@ -12,6 +11,11 @@ public enum Status {
 
     Status (String status){
         this.status = status;
+    }
+
+    @JsonValue
+    public String getStatus(){
+        return status;
     }
 
 }

--- a/src/main/java/Problem/Math/AI/domain/attempt/entity/Status.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/entity/Status.java
@@ -1,4 +1,4 @@
-package Problem.Math.AI.domain.attempt;
+package Problem.Math.AI.domain.attempt.entity;
 
 import lombok.Getter;
 

--- a/src/main/java/Problem/Math/AI/domain/attempt/exception/AttemptException.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/exception/AttemptException.java
@@ -1,0 +1,10 @@
+package Problem.Math.AI.domain.attempt.exception;
+
+public class AttemptException extends RuntimeException{
+    public AttemptException(String msg, Throwable cause){
+        super(msg, cause);
+    }
+    public AttemptException(String msg){
+        super(msg);
+    }
+}

--- a/src/main/java/Problem/Math/AI/domain/attempt/repository/AttemptRepository.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/repository/AttemptRepository.java
@@ -1,0 +1,10 @@
+package Problem.Math.AI.domain.attempt.repository;
+
+import Problem.Math.AI.domain.attempt.entity.ProblemAttempt;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AttemptRepository extends JpaRepository<ProblemAttempt, Long> {
+
+}

--- a/src/main/java/Problem/Math/AI/domain/attempt/service/AttemptService.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/service/AttemptService.java
@@ -1,0 +1,37 @@
+package Problem.Math.AI.domain.attempt.service;
+
+import Problem.Math.AI.domain.attempt.dto.AttemptMarkRequest;
+import Problem.Math.AI.domain.attempt.exception.AttemptException;
+import Problem.Math.AI.domain.attempt.repository.AttemptRepository;
+import Problem.Math.AI.domain.problem.repository.ProblemRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AttemptService {
+
+    private final ProblemRepository problemRepository;
+    private final AttemptRepository attemptRepository;
+
+    /**
+     * 1. 답 체크
+     * 2. PENDDING 상태의 시도 저장
+     * 3. GPT에게 비동기로 분석 요청
+     * 3-1. 시도 응답
+     * @param attempt
+     */
+    public void markAttemptSolution(AttemptMarkRequest attempt) {
+        checkAnswer(attempt);
+    }
+
+    private void checkAnswer(AttemptMarkRequest attemptMark) {
+        Integer expectAnswer = problemRepository.findAnswerById(attemptMark.getProblemId());
+        Integer realAnswer = attemptMark.getAnswer();
+        if(!expectAnswer.equals(realAnswer)){
+            throw new AttemptException("틀린 답입니다. 다른 답을 전달해주세요.");
+        }
+    }
+}

--- a/src/main/java/Problem/Math/AI/domain/attempt/service/AttemptService.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/service/AttemptService.java
@@ -1,12 +1,22 @@
 package Problem.Math.AI.domain.attempt.service;
 
 import Problem.Math.AI.domain.attempt.dto.AttemptMarkRequest;
+import Problem.Math.AI.domain.attempt.dto.SimpleMarkResponse;
+import Problem.Math.AI.domain.attempt.entity.ProblemAttempt;
+import Problem.Math.AI.domain.attempt.entity.Status;
 import Problem.Math.AI.domain.attempt.exception.AttemptException;
 import Problem.Math.AI.domain.attempt.repository.AttemptRepository;
+import Problem.Math.AI.domain.gpt.GptAsyncService;
+import Problem.Math.AI.domain.gpt.exception.GptAsyncException;
+import Problem.Math.AI.domain.problem.entity.Problem;
+import Problem.Math.AI.domain.problem.exception.ProblemException;
 import Problem.Math.AI.domain.problem.repository.ProblemRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -15,6 +25,7 @@ public class AttemptService {
 
     private final ProblemRepository problemRepository;
     private final AttemptRepository attemptRepository;
+    private final GptAsyncService gptAsyncService;
 
     /**
      * 1. 답 체크
@@ -23,15 +34,43 @@ public class AttemptService {
      * 3-1. 시도 응답
      * @param attempt
      */
-    public void markAttemptSolution(AttemptMarkRequest attempt) {
-        checkAnswer(attempt);
+    public SimpleMarkResponse markAttemptSolution(AttemptMarkRequest attempt) {
+        Map<Boolean, Problem> check = checkAnswer(attempt);
+        ProblemAttempt problemAttempt;
+        if(check.get(Boolean.TRUE) != null){ // 참인 경우
+            // gpt에 분석 요청
+            try{
+                gptAsyncService.markRequest(attempt);
+            } catch (RuntimeException g){
+                throw new GptAsyncException(g.getMessage(), g.getCause());
+            }
+            problemAttempt = ProblemAttempt.toEntity(attempt, check.get(Boolean.TRUE), Status.PENDING);
+        } else{
+            problemAttempt = ProblemAttempt.toEntity(attempt, check.get(Boolean.FALSE), Status.FAIL);
+        }
+        try{
+            ProblemAttempt savedProblemAttempt = attemptRepository.save(problemAttempt);
+            return SimpleMarkResponse.builder()
+                    .problemId(savedProblemAttempt.getId())
+                    .status(savedProblemAttempt.getStatus())
+                    .build();
+        } catch (RuntimeException e){
+            throw new AttemptException(e.getMessage(), e.getCause());
+        }
     }
 
-    private void checkAnswer(AttemptMarkRequest attemptMark) {
-        Integer expectAnswer = problemRepository.findAnswerById(attemptMark.getProblemId());
+    private Map<Boolean, Problem> checkAnswer(AttemptMarkRequest attemptMark) {
+        Problem problem = problemRepository.findById(attemptMark.getProblemId())
+                .orElseThrow(() -> new ProblemException("존재하지 않는 문제입니다."));
+        Integer expectAnswer = problem.getAnswer();
         Integer realAnswer = attemptMark.getAnswer();
         if(!expectAnswer.equals(realAnswer)){
-            throw new AttemptException("틀린 답입니다. 다른 답을 전달해주세요.");
+            return new HashMap<>(){{
+                put(false, problem);
+            }};
         }
+        return new HashMap<>(){{
+            put(true, problem);
+        }};
     }
 }

--- a/src/main/java/Problem/Math/AI/domain/attempt/service/AttemptService.java
+++ b/src/main/java/Problem/Math/AI/domain/attempt/service/AttemptService.java
@@ -57,6 +57,7 @@ public class AttemptService {
             }
         }
         return SimpleMarkResponse.builder()
+                .attemptId(savedProblemAttempt.getId())
                 .problemId(savedProblemAttempt.getId())
                 .status(savedProblemAttempt.getStatus())
                 .build();

--- a/src/main/java/Problem/Math/AI/domain/gpt/GptAsyncService.java
+++ b/src/main/java/Problem/Math/AI/domain/gpt/GptAsyncService.java
@@ -1,9 +1,0 @@
-package Problem.Math.AI.domain.gpt;
-
-import Problem.Math.AI.domain.attempt.dto.AttemptMarkRequest;
-import org.springframework.stereotype.Service;
-
-@Service
-public interface GptAsyncService {
-    void markRequest(AttemptMarkRequest attempt);
-}

--- a/src/main/java/Problem/Math/AI/domain/gpt/GptAsyncService.java
+++ b/src/main/java/Problem/Math/AI/domain/gpt/GptAsyncService.java
@@ -1,0 +1,9 @@
+package Problem.Math.AI.domain.gpt;
+
+import Problem.Math.AI.domain.attempt.dto.AttemptMarkRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface GptAsyncService {
+    void markRequest(AttemptMarkRequest attempt);
+}

--- a/src/main/java/Problem/Math/AI/domain/gpt/dto/EncodedImage.java
+++ b/src/main/java/Problem/Math/AI/domain/gpt/dto/EncodedImage.java
@@ -1,0 +1,16 @@
+package Problem.Math.AI.domain.gpt.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EncodedImage {
+    @JsonProperty("url")
+    private String url;
+}

--- a/src/main/java/Problem/Math/AI/domain/gpt/dto/MessageType.java
+++ b/src/main/java/Problem/Math/AI/domain/gpt/dto/MessageType.java
@@ -1,0 +1,33 @@
+package Problem.Math.AI.domain.gpt.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum MessageType {
+    TEXT("text"),
+    IMAGE_URL("image_url");
+    private String type;
+    MessageType(String type){
+        this.type = type;
+    }
+
+    @JsonValue // for 직렬화
+    public String getType() {
+        return type;
+    }
+
+    @JsonCreator // for 역직렬화
+    public static MessageType from(String val){
+        for(MessageType messageType : MessageType.values()){
+            if(messageType.getType().equals(val)){
+                return messageType;
+            }
+        }
+        throw new RuntimeException("부정확한 메세지 타입입니다.");
+    }
+
+    @Override
+    public String toString(){
+        return type;
+    }
+}

--- a/src/main/java/Problem/Math/AI/domain/gpt/dto/ReqContent.java
+++ b/src/main/java/Problem/Math/AI/domain/gpt/dto/ReqContent.java
@@ -1,0 +1,24 @@
+package Problem.Math.AI.domain.gpt.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = ReqTextContent.class, name = "text"),
+        @JsonSubTypes.Type(value = ReqImageContent.class, name = "image_url")
+})
+public abstract class ReqContent {
+    public abstract MessageType getType();
+    public abstract String getValue();
+
+    @Override
+    public String toString(){
+        return new StringBuilder().append("{\n type : ").append(getType()).append('\n')
+                .append("content : ").append(getValue()).append("\n }")
+                .toString();
+    }
+}

--- a/src/main/java/Problem/Math/AI/domain/gpt/dto/ReqImageContent.java
+++ b/src/main/java/Problem/Math/AI/domain/gpt/dto/ReqImageContent.java
@@ -1,0 +1,29 @@
+package Problem.Math.AI.domain.gpt.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonTypeName("image_url")
+public class ReqImageContent extends ReqContent {
+
+    private final MessageType type = MessageType.IMAGE_URL;
+    @JsonProperty("image_url")
+    private EncodedImage encodedImage;
+
+    @Override
+    public MessageType getType() {
+        return type;
+    }
+
+    // Getters and setters
+    @Override
+    @JsonIgnore
+    public String getValue() {
+        return encodedImage.getUrl();
+    }
+}

--- a/src/main/java/Problem/Math/AI/domain/gpt/dto/ReqTextContent.java
+++ b/src/main/java/Problem/Math/AI/domain/gpt/dto/ReqTextContent.java
@@ -1,0 +1,27 @@
+package Problem.Math.AI.domain.gpt.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonTypeName("text")
+public class ReqTextContent extends ReqContent {
+
+    private final MessageType type = MessageType.TEXT;
+
+    @JsonProperty("text")
+    private String text;
+
+    @Override
+    public MessageType getType() {
+        return type;
+    }
+
+    @Override
+    public String getValue() {
+        return text;
+    }
+}

--- a/src/main/java/Problem/Math/AI/domain/gpt/dto/VisionReqDto.java
+++ b/src/main/java/Problem/Math/AI/domain/gpt/dto/VisionReqDto.java
@@ -1,0 +1,25 @@
+package Problem.Math.AI.domain.gpt.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class VisionReqDto {
+    private List<ReqContent> contents;
+    public VisionReqDto(ReqContent content){
+        this.contents = List.of(content);
+    }
+    @Override
+    public String toString(){
+        StringBuilder sb = new StringBuilder();
+        for(ReqContent reqContent : contents){
+            sb.append(reqContent).append("\n");
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/Problem/Math/AI/domain/gpt/exception/GptAsyncException.java
+++ b/src/main/java/Problem/Math/AI/domain/gpt/exception/GptAsyncException.java
@@ -1,0 +1,11 @@
+package Problem.Math.AI.domain.gpt.exception;
+
+public class GptAsyncException extends RuntimeException {
+    public GptAsyncException(String message, Throwable g) {
+        super(message, g);
+    }
+
+    public GptAsyncException(String msg){
+        super(msg);
+    }
+}

--- a/src/main/java/Problem/Math/AI/domain/gpt/service/GptAsyncService.java
+++ b/src/main/java/Problem/Math/AI/domain/gpt/service/GptAsyncService.java
@@ -4,7 +4,6 @@ import Problem.Math.AI.domain.attempt.dto.AttemptAnalysisRequest;
 import Problem.Math.AI.domain.gpt.dto.VisionReqDto;
 import org.springframework.stereotype.Service;
 
-@Service
 public interface GptAsyncService {
     void attemptMarkRequest(AttemptAnalysisRequest attempt);
     VisionReqDto attemptMarkResponse();

--- a/src/main/java/Problem/Math/AI/domain/gpt/service/GptAsyncService.java
+++ b/src/main/java/Problem/Math/AI/domain/gpt/service/GptAsyncService.java
@@ -1,0 +1,11 @@
+package Problem.Math.AI.domain.gpt.service;
+
+import Problem.Math.AI.domain.attempt.dto.AttemptAnalysisRequest;
+import Problem.Math.AI.domain.gpt.dto.VisionReqDto;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface GptAsyncService {
+    void attemptMarkRequest(AttemptAnalysisRequest attempt);
+    VisionReqDto attemptMarkResponse();
+}

--- a/src/main/java/Problem/Math/AI/domain/gpt/service/GptAsyncServiceImpl.java
+++ b/src/main/java/Problem/Math/AI/domain/gpt/service/GptAsyncServiceImpl.java
@@ -1,0 +1,18 @@
+package Problem.Math.AI.domain.gpt.service;
+
+import Problem.Math.AI.domain.attempt.dto.AttemptAnalysisRequest;
+import Problem.Math.AI.domain.gpt.dto.VisionReqDto;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GptAsyncServiceImpl implements GptAsyncService{
+    @Override
+    public void attemptMarkRequest(AttemptAnalysisRequest attempt) {
+
+    }
+
+    @Override
+    public VisionReqDto attemptMarkResponse() {
+        return null;
+    }
+}

--- a/src/main/java/Problem/Math/AI/domain/problem/controller/ProblemController.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/controller/ProblemController.java
@@ -1,10 +1,24 @@
 package Problem.Math.AI.domain.problem.controller;
 
+import Problem.Math.AI.domain.problem.dto.ProblemCreationRequest;
+import Problem.Math.AI.domain.problem.dto.ProblemCreationResponse;
+import Problem.Math.AI.domain.problem.service.ProblemService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/problem")
 public class ProblemController {
+
+    private final ProblemService problemService;
+
+    @GetMapping
+    public ProblemCreationResponse createProblem(@RequestBody ProblemCreationRequest request){
+        return null;
+    }
 
 }

--- a/src/main/java/Problem/Math/AI/domain/problem/controller/ProblemController.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/controller/ProblemController.java
@@ -4,6 +4,7 @@ import Problem.Math.AI.domain.problem.dto.ProblemCreationRequest;
 import Problem.Math.AI.domain.problem.dto.ProblemCreationResponse;
 import Problem.Math.AI.domain.problem.service.ProblemService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -14,8 +15,9 @@ public class ProblemController {
     private final ProblemService problemService;
 
     @PostMapping
-    public ProblemCreationResponse createProblem(@RequestBody ProblemCreationRequest request){
-        return problemService.createProblem(request);
+    public ResponseEntity<ProblemCreationResponse> createProblem(@RequestBody ProblemCreationRequest request){
+        ProblemCreationResponse response = problemService.createProblem(request);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/Problem/Math/AI/domain/problem/controller/ProblemController.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/controller/ProblemController.java
@@ -4,10 +4,7 @@ import Problem.Math.AI.domain.problem.dto.ProblemCreationRequest;
 import Problem.Math.AI.domain.problem.dto.ProblemCreationResponse;
 import Problem.Math.AI.domain.problem.service.ProblemService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,9 +13,9 @@ public class ProblemController {
 
     private final ProblemService problemService;
 
-    @GetMapping
+    @PostMapping
     public ProblemCreationResponse createProblem(@RequestBody ProblemCreationRequest request){
-        return null;
+        return problemService.createProblem(request);
     }
 
 }

--- a/src/main/java/Problem/Math/AI/domain/problem/dto/ConceptTagRequest.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/dto/ConceptTagRequest.java
@@ -1,0 +1,10 @@
+package Problem.Math.AI.domain.problem.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ConceptTagRequest {
+    private String name;
+}

--- a/src/main/java/Problem/Math/AI/domain/problem/dto/ConceptTagResponse.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/dto/ConceptTagResponse.java
@@ -5,11 +5,14 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-
+import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
+@NoArgsConstructor
 @AllArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class ProblemCreationResponse {
-    private Long problemId;
+public class ConceptTagResponse {
+    private Long conceptTagId;
+    private String conceptTagName;
 }

--- a/src/main/java/Problem/Math/AI/domain/problem/dto/OfficialSolutionCreationRequest.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/dto/OfficialSolutionCreationRequest.java
@@ -3,6 +3,8 @@ package Problem.Math.AI.domain.problem.dto;
 import Problem.Math.AI.common.dto.ContentRequest;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,6 +12,8 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@Builder
+@AllArgsConstructor
 @JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class OfficialSolutionCreationRequest {
     private String source;

--- a/src/main/java/Problem/Math/AI/domain/problem/dto/OfficialSolutionCreationRequest.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/dto/OfficialSolutionCreationRequest.java
@@ -1,0 +1,18 @@
+package Problem.Math.AI.domain.problem.dto;
+
+import Problem.Math.AI.common.dto.ContentRequest;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@JsonNaming(value = PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class OfficialSolutionCreationRequest {
+    private String source;
+    private String textSolution;
+    private List<ContentRequest> imgSolutions;
+}

--- a/src/main/java/Problem/Math/AI/domain/problem/dto/ProblemCreationRequest.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/dto/ProblemCreationRequest.java
@@ -4,6 +4,7 @@ package Problem.Math.AI.domain.problem.dto;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +12,8 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@Builder
+@AllArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class ProblemCreationRequest {
     private Long userId;

--- a/src/main/java/Problem/Math/AI/domain/problem/dto/ProblemCreationRequest.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/dto/ProblemCreationRequest.java
@@ -19,5 +19,5 @@ public class ProblemCreationRequest {
     private Double difficulty;
     private Integer answer;
     private List<Long> conceptTags;
-    private List<OfficialSolutionCreationRequest> officialSolution;
+    private OfficialSolutionCreationRequest officialSolution;
 }

--- a/src/main/java/Problem/Math/AI/domain/problem/dto/ProblemCreationResponse.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/dto/ProblemCreationResponse.java
@@ -1,23 +1,30 @@
 package Problem.Math.AI.domain.problem.dto;
 
-
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.boot.model.naming.NamingStrategyHelper;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-public class ProblemCreationRequest {
+public class ProblemCreationResponse {
+    private Long problemId;
+    private LocalDateTime createDate;
     private Long userId;
-    private String name;
+    private String userName;
+    private String problemName;
     private String imgUrl;
     private Double difficulty;
     private Integer answer;
     private List<Long> conceptTags;
-    private List<OfficialSolutionCreationRequest> officialSolution;
 }

--- a/src/main/java/Problem/Math/AI/domain/problem/entity/OfficialSolution.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/entity/OfficialSolution.java
@@ -1,16 +1,22 @@
 package Problem.Math.AI.domain.problem.entity;
 
+import Problem.Math.AI.common.dto.ContentRequest;
 import Problem.Math.AI.common.entity.BaseEntity;
+import Problem.Math.AI.domain.problem.dto.OfficialSolutionCreationRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Entity
-@Builder
+@SuperBuilder
 @Table(name = "official_solution")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -25,8 +31,23 @@ public class OfficialSolution extends BaseEntity {
     @Column
     private String source;
 
-    @OneToMany
+    @OneToMany(fetch = FetchType.LAZY)
     @JoinColumn(name = "official_solution_id")
     private Set<SolutionContentEntity> solutionContents;
 
+    public static OfficialSolution toEntity(OfficialSolutionCreationRequest request) {
+
+        return OfficialSolution.builder()
+                .createDate(LocalDateTime.now())
+                .textSolution(request.getTextSolution())
+                .source(request.getSource())
+                .solutionContents(toEntity(request.getImgSolutions()))
+                .build();
+    }
+
+    private static Set<SolutionContentEntity> toEntity(List<ContentRequest> requests){
+        return requests.parallelStream().map( req -> SolutionContentEntity.builder()
+                                                    .imgUrl(req.getImgUrl()).build())
+                .collect(Collectors.toSet());
+    }
 }

--- a/src/main/java/Problem/Math/AI/domain/problem/entity/OfficialSolution.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/entity/OfficialSolution.java
@@ -1,6 +1,6 @@
 package Problem.Math.AI.domain.problem.entity;
 
-import Problem.Math.AI.domain.BaseEntity;
+import Problem.Math.AI.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/Problem/Math/AI/domain/problem/entity/Problem.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/entity/Problem.java
@@ -28,6 +28,7 @@ public class Problem extends BaseEntity {
     @Column
     private Double difficulty;
 
+    @Getter
     @Column
     private Integer answer;
 

--- a/src/main/java/Problem/Math/AI/domain/problem/entity/Problem.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/entity/Problem.java
@@ -12,7 +12,7 @@ import java.util.Set;
 @SuperBuilder
 @Table(name = "problem")
 @AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor()
 public class Problem extends BaseEntity {
 
     @Getter

--- a/src/main/java/Problem/Math/AI/domain/problem/entity/Problem.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/entity/Problem.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
+import java.time.LocalDateTime;
 import java.util.Set;
 
 @Entity
@@ -41,15 +42,15 @@ public class Problem extends BaseEntity {
     private OfficialSolution officialSolution;
 
 
-    public static Problem toEntity(ProblemCreationRequest request, Set<ProblemConceptTag> tags, OfficialSolution solution){
+    public static Problem toEntity(ProblemCreationRequest request, OfficialSolution solution){
         return Problem.builder()
                 .userId(request.getUserId())
                 .name(request.getName())
                 .imgUrl(request.getImgUrl())
                 .difficulty(request.getDifficulty())
                 .answer(request.getAnswer())
-                .problemConceptTags(tags)
                 .officialSolution(solution)
+                .createDate(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/Problem/Math/AI/domain/problem/entity/Problem.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/entity/Problem.java
@@ -3,20 +3,19 @@ package Problem.Math.AI.domain.problem.entity;
 import Problem.Math.AI.common.entity.BaseEntity;
 import Problem.Math.AI.domain.problem.dto.ProblemCreationRequest;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.Set;
 
 @Entity
-@Builder
+@SuperBuilder
 @Table(name = "problem")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Problem extends BaseEntity {
 
+    @Getter
     @Column(name = "user_id")
     private Long userId;
 
@@ -32,16 +31,16 @@ public class Problem extends BaseEntity {
     @Column
     private Integer answer;
 
-    @OneToMany(cascade = CascadeType.ALL)
+    @OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinColumn(name = "problem_id")
     private Set<ProblemConceptTag> problemConceptTags;
 
-    @OneToOne(cascade = CascadeType.ALL)
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinColumn(name = "official_solution_id")
     private OfficialSolution officialSolution;
 
 
-    public Problem toEntity(ProblemCreationRequest request, Set<ProblemConceptTag> tags, OfficialSolution solution){
+    public static Problem toEntity(ProblemCreationRequest request, Set<ProblemConceptTag> tags, OfficialSolution solution){
         return Problem.builder()
                 .userId(request.getUserId())
                 .name(request.getName())

--- a/src/main/java/Problem/Math/AI/domain/problem/entity/Problem.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/entity/Problem.java
@@ -1,6 +1,7 @@
 package Problem.Math.AI.domain.problem.entity;
 
-import Problem.Math.AI.domain.BaseEntity;
+import Problem.Math.AI.common.entity.BaseEntity;
+import Problem.Math.AI.domain.problem.dto.ProblemCreationRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -31,12 +32,24 @@ public class Problem extends BaseEntity {
     @Column
     private Integer answer;
 
-    @OneToMany
+    @OneToMany(cascade = CascadeType.ALL)
     @JoinColumn(name = "problem_id")
     private Set<ProblemConceptTag> problemConceptTags;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "official_solution_id")
     private OfficialSolution officialSolution;
 
+
+    public Problem toEntity(ProblemCreationRequest request, Set<ProblemConceptTag> tags, OfficialSolution solution){
+        return Problem.builder()
+                .userId(request.getUserId())
+                .name(request.getName())
+                .imgUrl(request.getImgUrl())
+                .difficulty(request.getDifficulty())
+                .answer(request.getAnswer())
+                .problemConceptTags(tags)
+                .officialSolution(solution)
+                .build();
+    }
 }

--- a/src/main/java/Problem/Math/AI/domain/problem/entity/ProblemConceptTag.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/entity/ProblemConceptTag.java
@@ -17,11 +17,11 @@ public class ProblemConceptTag {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "problem_id", nullable = false)
+    @JoinColumn(name = "problem_id")
     private Problem problem;
 
     @ManyToOne
-    @JoinColumn(name = "concep_tag_id", nullable = false)
+    @JoinColumn(name = "concep_tag_id")
     private ConceptTag conceptTag;
 
 }

--- a/src/main/java/Problem/Math/AI/domain/problem/entity/SolutionContentEntity.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/entity/SolutionContentEntity.java
@@ -1,6 +1,6 @@
 package Problem.Math.AI.domain.problem.entity;
 
-import Problem.Math.AI.domain.ContentEntity;
+import Problem.Math.AI.common.entity.ContentEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/Problem/Math/AI/domain/problem/entity/SolutionContentEntity.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/entity/SolutionContentEntity.java
@@ -6,9 +6,10 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
-@Builder
+@SuperBuilder
 @Table(name = "solution_content")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/Problem/Math/AI/domain/problem/exception/InvalidConceptTagException.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/exception/InvalidConceptTagException.java
@@ -1,0 +1,12 @@
+package Problem.Math.AI.domain.problem.exception;
+
+public class InvalidConceptTagException extends ProblemException{
+
+    public InvalidConceptTagException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+    public InvalidConceptTagException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/Problem/Math/AI/domain/problem/exception/ProblemException.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/exception/ProblemException.java
@@ -1,0 +1,10 @@
+package Problem.Math.AI.domain.problem.exception;
+
+public class ProblemException extends RuntimeException{
+    public ProblemException(String msg, Throwable cause){
+        super(msg, cause);
+    }
+    public ProblemException(String msg){
+        super(msg);
+    }
+}

--- a/src/main/java/Problem/Math/AI/domain/problem/repository/ConceptTagRepository.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/repository/ConceptTagRepository.java
@@ -1,0 +1,12 @@
+package Problem.Math.AI.domain.problem.repository;
+
+import Problem.Math.AI.domain.problem.entity.ConceptTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ConceptTagRepository extends JpaRepository<ConceptTag, Long> {
+    List<ConceptTag> findByIdIn(List<Long> ids);
+}

--- a/src/main/java/Problem/Math/AI/domain/problem/repository/OfficialSolutionRepository.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/repository/OfficialSolutionRepository.java
@@ -1,0 +1,9 @@
+package Problem.Math.AI.domain.problem.repository;
+
+import Problem.Math.AI.domain.problem.entity.OfficialSolution;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OfficialSolutionRepository extends JpaRepository<OfficialSolution, Long> {
+}

--- a/src/main/java/Problem/Math/AI/domain/problem/repository/ProblemConceptTagRepository.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/repository/ProblemConceptTagRepository.java
@@ -1,0 +1,9 @@
+package Problem.Math.AI.domain.problem.repository;
+
+import Problem.Math.AI.domain.problem.entity.ProblemConceptTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProblemConceptTagRepository extends JpaRepository<ProblemConceptTag, Long> {
+}

--- a/src/main/java/Problem/Math/AI/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/repository/ProblemRepository.java
@@ -2,8 +2,13 @@ package Problem.Math.AI.domain.problem.repository;
 
 import Problem.Math.AI.domain.problem.entity.Problem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProblemRepository extends JpaRepository<Problem, Long> {
+
+    @Query(value = "Select p.answer FROM Problem p WHERE p.id = :id")
+    Integer findAnswerById(@Param("id") Long id);
 }

--- a/src/main/java/Problem/Math/AI/domain/problem/repository/ProblemRepository.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/repository/ProblemRepository.java
@@ -1,0 +1,9 @@
+package Problem.Math.AI.domain.problem.repository;
+
+import Problem.Math.AI.domain.problem.entity.Problem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProblemRepository extends JpaRepository<Problem, Long> {
+}

--- a/src/main/java/Problem/Math/AI/domain/problem/service/ProblemService.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/service/ProblemService.java
@@ -1,15 +1,70 @@
 package Problem.Math.AI.domain.problem.service;
 
-import Problem.Math.AI.domain.problem.dto.ProblemCreationRequest;
-import Problem.Math.AI.domain.problem.dto.ProblemCreationResponse;
+import Problem.Math.AI.domain.problem.dto.*;
+import Problem.Math.AI.domain.problem.entity.ConceptTag;
+import Problem.Math.AI.domain.problem.entity.OfficialSolution;
+import Problem.Math.AI.domain.problem.entity.Problem;
+import Problem.Math.AI.domain.problem.entity.ProblemConceptTag;
+import Problem.Math.AI.domain.problem.exception.InvalidConceptTagException;
+import Problem.Math.AI.domain.problem.repository.ConceptTagRepository;
+import Problem.Math.AI.domain.problem.repository.OfficialSolutionRepository;
+import Problem.Math.AI.domain.problem.repository.ProblemRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ProblemService {
 
+    private final ProblemRepository problemRepository;
+    private final ConceptTagRepository conceptTagRepository;
+    private final OfficialSolutionRepository officialSolutionRepository;
+
+    /**
+     * 문제를 만들 때 순서
+     * 1. Official Solution을 저장
+     * 2. ProblemContentTag를 저장
+     * 3. Problem을 저장 -> (1), (2)를 연관시켜서 저장
+     *
+     * 조건
+     * 1. tag가 이미 존재하는 태그여야한다.
+     * 2. 부족하면 나중에 추가로 tag를 달 수 있도록 해야함.
+     *
+     * @param request
+     * @return
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public ProblemCreationResponse createProblem(ProblemCreationRequest request){
-        return null;
+        OfficialSolution officialSolution = OfficialSolution.toEntity(request.getOfficialSolution());
+        Set<ProblemConceptTag> conceptTags = createProblemConceptTag(request.getConceptTags());
+        Problem problem = Problem.toEntity(request, conceptTags, officialSolution);
+        Problem savedProblem = problemRepository.save(problem);
+        return new ProblemCreationResponse(savedProblem.getUserId());
     }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public List<ConceptTag> findConceptTag(List<Long> ids){
+        List<ConceptTag> conceptTags = conceptTagRepository.findByIdIn(ids);
+        if(ids.size() != conceptTags.size()){
+            throw new InvalidConceptTagException("존재하지 않는 개념 태그가 있습니다. 태그를 추가해서 사용해주세요.");
+        }
+        return conceptTags;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Set<ProblemConceptTag> createProblemConceptTag(List<Long> ids){
+        return findConceptTag(ids).stream()
+                .map(tag -> ProblemConceptTag
+                        .builder().conceptTag(tag).build())
+                .collect(Collectors.toSet());
+    }
+
 }

--- a/src/main/java/Problem/Math/AI/domain/problem/service/ProblemService.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/service/ProblemService.java
@@ -47,7 +47,7 @@ public class ProblemService {
         Set<ProblemConceptTag> conceptTags = createProblemConceptTag(request.getConceptTags());
         Problem problem = Problem.toEntity(request, conceptTags, officialSolution);
         Problem savedProblem = problemRepository.save(problem);
-        return new ProblemCreationResponse(savedProblem.getUserId());
+        return new ProblemCreationResponse(savedProblem.getId());
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/Problem/Math/AI/domain/problem/service/ProblemService.java
+++ b/src/main/java/Problem/Math/AI/domain/problem/service/ProblemService.java
@@ -1,0 +1,15 @@
+package Problem.Math.AI.domain.problem.service;
+
+import Problem.Math.AI.domain.problem.dto.ProblemCreationRequest;
+import Problem.Math.AI.domain.problem.dto.ProblemCreationResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProblemService {
+
+    public ProblemCreationResponse createProblem(ProblemCreationRequest request){
+        return null;
+    }
+}

--- a/src/main/java/Problem/Math/AI/domain/question/Answer.java
+++ b/src/main/java/Problem/Math/AI/domain/question/Answer.java
@@ -6,10 +6,11 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 
 @Entity
-@Builder
+@SuperBuilder
 @Table(name = "problem_attempt")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/Problem/Math/AI/domain/question/Answer.java
+++ b/src/main/java/Problem/Math/AI/domain/question/Answer.java
@@ -11,7 +11,7 @@ import lombok.experimental.SuperBuilder;
 
 @Entity
 @SuperBuilder
-@Table(name = "problem_attempt")
+@Table(name = "answer")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Answer extends BaseEntity {

--- a/src/main/java/Problem/Math/AI/domain/question/Answer.java
+++ b/src/main/java/Problem/Math/AI/domain/question/Answer.java
@@ -1,6 +1,6 @@
 package Problem.Math.AI.domain.question;
 
-import Problem.Math.AI.domain.BaseEntity;
+import Problem.Math.AI.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/Problem/Math/AI/domain/question/AnswerContentEntity.java
+++ b/src/main/java/Problem/Math/AI/domain/question/AnswerContentEntity.java
@@ -1,6 +1,6 @@
 package Problem.Math.AI.domain.question;
 
-import Problem.Math.AI.domain.ContentEntity;
+import Problem.Math.AI.common.entity.ContentEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;

--- a/src/main/java/Problem/Math/AI/domain/question/AnswerContentEntity.java
+++ b/src/main/java/Problem/Math/AI/domain/question/AnswerContentEntity.java
@@ -9,8 +9,9 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
-@Entity
+@SuperBuilder
 @Builder
 @Table(name = "answer_content")
 @AllArgsConstructor

--- a/src/main/java/Problem/Math/AI/domain/question/Question.java
+++ b/src/main/java/Problem/Math/AI/domain/question/Question.java
@@ -1,6 +1,6 @@
 package Problem.Math.AI.domain.question;
 
-import Problem.Math.AI.domain.BaseEntity;
+import Problem.Math.AI.common.entity.BaseEntity;
 import Problem.Math.AI.domain.problem.entity.Problem;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/Problem/Math/AI/domain/question/Question.java
+++ b/src/main/java/Problem/Math/AI/domain/question/Question.java
@@ -4,12 +4,13 @@ import Problem.Math.AI.common.entity.BaseEntity;
 import Problem.Math.AI.domain.problem.entity.Problem;
 import jakarta.persistence.*;
 import lombok.*;
+import lombok.experimental.SuperBuilder;
 
 import java.util.Set;
 
 
 @Entity
-@Builder
+@SuperBuilder
 @Table(name = "problem_attempt")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/Problem/Math/AI/domain/question/Question.java
+++ b/src/main/java/Problem/Math/AI/domain/question/Question.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 @Entity
 @SuperBuilder
-@Table(name = "problem_attempt")
+@Table(name = "question")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Question extends BaseEntity {

--- a/src/main/java/Problem/Math/AI/domain/question/QuestionContentEntity.java
+++ b/src/main/java/Problem/Math/AI/domain/question/QuestionContentEntity.java
@@ -9,9 +9,10 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Entity
-@Builder
+@SuperBuilder
 @Table(name = "solution_content")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/Problem/Math/AI/domain/question/QuestionContentEntity.java
+++ b/src/main/java/Problem/Math/AI/domain/question/QuestionContentEntity.java
@@ -13,7 +13,7 @@ import lombok.experimental.SuperBuilder;
 
 @Entity
 @SuperBuilder
-@Table(name = "solution_content")
+@Table(name = "question_content")
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuestionContentEntity extends ContentEntity {

--- a/src/main/java/Problem/Math/AI/domain/question/QuestionContentEntity.java
+++ b/src/main/java/Problem/Math/AI/domain/question/QuestionContentEntity.java
@@ -1,6 +1,6 @@
 package Problem.Math.AI.domain.question;
 
-import Problem.Math.AI.domain.ContentEntity;
+import Problem.Math.AI.common.entity.ContentEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;

--- a/src/main/java/Problem/Math/AI/domain/s3file/dto/PreSignedUrlRequest.java
+++ b/src/main/java/Problem/Math/AI/domain/s3file/dto/PreSignedUrlRequest.java
@@ -1,5 +1,6 @@
 package Problem.Math.AI.domain.s3file.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +13,7 @@ import java.util.Map;
 @Builder
 @AllArgsConstructor
 public class PreSignedUrlRequest {
+    @JsonProperty("key-name")
     private String keyName;
     private Map<String, String> metadata;
 }

--- a/src/main/java/Problem/Math/AI/domain/s3file/dto/PreSignedUrlResponse.java
+++ b/src/main/java/Problem/Math/AI/domain/s3file/dto/PreSignedUrlResponse.java
@@ -1,5 +1,7 @@
 package Problem.Math.AI.domain.s3file.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +13,7 @@ import java.util.Map;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class PreSignedUrlResponse {
     private String keyName;
     private Map<String, String> metadata;

--- a/src/test/java/Problem/Math/AI/domain/problem/ProblemCreateTest.java
+++ b/src/test/java/Problem/Math/AI/domain/problem/ProblemCreateTest.java
@@ -1,0 +1,73 @@
+package Problem.Math.AI.domain.problem;
+
+import Problem.Math.AI.common.dto.ContentRequest;
+import Problem.Math.AI.domain.problem.dto.OfficialSolutionCreationRequest;
+import Problem.Math.AI.domain.problem.dto.ProblemCreationRequest;
+import Problem.Math.AI.domain.problem.dto.ProblemCreationResponse;
+import Problem.Math.AI.domain.problem.entity.ConceptTag;
+import Problem.Math.AI.domain.problem.entity.OfficialSolution;
+import Problem.Math.AI.domain.problem.entity.Problem;
+import Problem.Math.AI.domain.problem.entity.ProblemConceptTag;
+import Problem.Math.AI.domain.problem.repository.ConceptTagRepository;
+import Problem.Math.AI.domain.problem.repository.OfficialSolutionRepository;
+import Problem.Math.AI.domain.problem.repository.ProblemRepository;
+import Problem.Math.AI.domain.problem.service.ProblemService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ActiveProfiles("local")
+@SpringBootTest
+@AutoConfigureMockMvc
+class ProblemCreateTest {
+
+    @Autowired
+    ProblemService problemService;
+
+    @MockBean
+    ProblemRepository problemRepository;
+
+    @MockBean
+    ConceptTagRepository conceptTagRepository;
+
+    @MockBean
+    OfficialSolutionRepository officialSolutionRepository;
+
+    ProblemCreationRequest request = ProblemCreationRequest.builder()
+            .userId(1L)
+            .name("20xx년 x월 전국연합학력평가 19번")
+            .imgUrl("https://dsfsfsffds")
+            .difficulty(3.67)
+            .answer(4)
+            .conceptTags(List.of(1L, 2L))
+            .officialSolution(OfficialSolutionCreationRequest
+                    .builder()
+                    .source("인천 교육청")
+                    .textSolution("이거를 저렇게 해서 저거를 이렇게 하면~~")
+                    .imgSolutions(List.of(new ContentRequest("https://asb"),
+                            new ContentRequest("https://bd"),
+                            new ContentRequest("https://as")))
+                    .build())
+            .build();
+
+    @Test
+    public void givenRequest_whenCreateProblem_thenReturnResponse(){
+        when(conceptTagRepository.findByIdIn(any(List.class))).thenReturn(List.of(new ConceptTag(1L, "미적분"), new ConceptTag(2L, "확률")));
+        when(problemRepository.save(any(Problem.class))).thenAnswer(invocation -> Problem.builder().id(1L).build());
+        ProblemCreationResponse response = problemService.createProblem(request);
+        Assertions.assertEquals(new ProblemCreationResponse(1L).getProblemId(), response.getProblemId());
+    }
+
+}


### PR DESCRIPTION
## 진행한 일

1. 문제 생성 API 작성
2. Entity 중 틀린 테이블 명 수정 (question, question_content, ...)
3. 문제 풀이 시도 요청 API 작성
- 요청 body에 text와 image_url을 모두 넣을 수 있게 해서 이미지 api와 텍스트 api를 통일
4. gpt 비동기 서비스의 인터페이스 작성 

To Do 
1. gpt 비동기 서비스 DTO 맵퍼 구현
2. gpt 서비스 구현